### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ func handler(w http.ResponseWriter, req *http.Request, rateLimiter *redis_rate.L
     if !allowed {
         h := w.Header()
         h.Set("X-RateLimit-Limit", strconv.FormatInt(limit, 10))
-        h.Set("X-RateLimit-Remaining", strconv.FormatInt(limit-rate, 10))
+        h.Set("X-RateLimit-Remaining", strconv.FormatInt(rate, 10))
         delaySec := int64(delay/time.Second)
         h.Set("X-RateLimit-Delay", strconv.FormatInt(delaySec, 10))
         http.Error(w, "API rate limit exceeded.", 429)
@@ -34,7 +34,7 @@ func handler(w http.ResponseWriter, req *http.Request, rateLimiter *redis_rate.L
     }
 
     fmt.Fprintf(w, "Hello world!\n")
-    fmt.Fprint(w, "Rate limit remaining: ", strconv.FormatInt(limit-rate, 10))
+    fmt.Fprint(w, "Rate limit remaining: ", strconv.FormatInt(rate, 10))
 }
 
 func statusHandler(w http.ResponseWriter, req *http.Request, rateLimiter *redis_rate.Limiter) {


### PR DESCRIPTION
Hi,

I think there is a typo in the example you give in the README.md file.

Regards,