### PR TITLE
Include Limit in the Result

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -63,6 +63,7 @@ func (l *Limiter) AllowN(key string, n int) (*Result, error) {
 	}
 
 	res := &Result{
+		Limit:      l.limit.Rate,
 		Allowed:    values[0].(int64) == 0,
 		Remaining:  int(values[1].(int64)),
 		RetryAfter: dur(retryAfter),
@@ -79,6 +80,9 @@ func dur(f float64) time.Duration {
 }
 
 type Result struct {
+	//Limit reports the available limit
+	Limit int
+	
 	// Allowed reports whether event may happen at time now.
 	Allowed bool
 


### PR DESCRIPTION
Required to get the limit if the rate limiter was created in a different scope. Limit is required to add X-RateLimit-Limit header in response.