### PR TITLE
Add inspect function to consult without setting new values

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -130,3 +130,59 @@ return {
   tostring(reset_after),
 }
 `)
+
+var inspect = redis.NewScript(`
+-- this script has side-effects, so it requires replicate commands mode
+redis.replicate_commands()
+
+local rate_limit_key = KEYS[1]
+local burst = ARGV[1]
+local rate = ARGV[2]
+local period = ARGV[3]
+local cost = tonumber(ARGV[4])
+
+local emission_interval = period / rate
+local increment = emission_interval * cost
+local burst_offset = emission_interval * burst
+
+-- redis returns time as an array containing two integers: seconds of the epoch
+-- time (10 digits) and microseconds (6 digits). for convenience we need to
+-- convert them to a floating point number. the resulting number is 16 digits,
+-- bordering on the limits of a 64-bit double-precision floating point number.
+-- adjust the epoch to be relative to Jan 1, 2017 00:00:00 GMT to avoid floating
+-- point problems. this approach is good until "now" is 2,483,228,799 (Wed, 09
+-- Sep 2048 01:46:39 GMT), when the adjusted value is 16 digits.
+local jan_1_2017 = 1483228800
+local now = redis.call("TIME")
+now = (now[1] - jan_1_2017) + (now[2] / 1000000)
+
+local tat = redis.call("GET", rate_limit_key)
+
+if not tat then
+  tat = now
+else
+  tat = tonumber(tat)
+end
+
+tat = math.max(tat, now)
+
+local new_tat = tat + increment
+local allow_at = new_tat - burst_offset
+
+local diff = now - allow_at
+local remaining = math.floor(diff / emission_interval + 0.5)
+
+if remaining < 0 then
+  local reset_after = tat - now
+  local retry_after = diff * -1
+  return {
+    0, -- allowed
+    0, -- remaining
+    tostring(retry_after),
+    tostring(reset_after),
+  }
+end
+
+local retry_after = -1
+return {cost, remaining, tostring(retry_after), tostring(retry_after)}
+`)


### PR DESCRIPTION
Add inspect function to be able to check the buckets without dropping on them.

This is very similar to the allow method, only that it does not call the last redis.call("SET") to "drop on buckets".