### PR TITLE
Add Reset function to remove history of a key

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -130,3 +130,15 @@ return {
   tostring(reset_after),
 }
 `)
+
+var reset = redis.NewScript(`
+-- this script has side-effects, so it requires replicate commands mode
+redis.replicate_commands()
+
+local rate_limit_key = KEYS[1]
+local tat = redis.call("DEL", rate_limit_key)
+
+return {
+  tat,
+}
+`)

--- a/lua.go
+++ b/lua.go
@@ -130,15 +130,3 @@ return {
   tostring(reset_after),
 }
 `)
-
-var reset = redis.NewScript(`
--- this script has side-effects, so it requires replicate commands mode
-redis.replicate_commands()
-
-local rate_limit_key = KEYS[1]
-local tat = redis.call("DEL", rate_limit_key)
-
-return {
-  tat,
-}
-`)

--- a/rate.go
+++ b/rate.go
@@ -158,6 +158,15 @@ func (l Limiter) AllowAtMost(
 	return res, nil
 }
 
+// Reset gets a key and reset all limitations and previous usages
+func (l *Limiter) Reset(ctx context.Context, key string) error {
+	_, err := reset.Run(ctx, l.rdb, []string{redisPrefix + key}, nil).Result()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func dur(f float64) time.Duration {
 	if f == -1 {
 		return -1

--- a/rate.go
+++ b/rate.go
@@ -16,6 +16,7 @@ type rediser interface {
 	EvalSha(ctx context.Context, sha1 string, keys []string, args ...interface{}) *redis.Cmd
 	ScriptExists(ctx context.Context, hashes ...string) *redis.BoolSliceCmd
 	ScriptLoad(ctx context.Context, script string) *redis.StringCmd
+	Del(ctx context.Context, keys ...string) *redis.IntCmd
 }
 
 type Limit struct {
@@ -160,11 +161,7 @@ func (l Limiter) AllowAtMost(
 
 // Reset gets a key and reset all limitations and previous usages
 func (l *Limiter) Reset(ctx context.Context, key string) error {
-	_, err := reset.Run(ctx, l.rdb, []string{redisPrefix + key}, nil).Result()
-	if err != nil {
-		return err
-	}
-	return nil
+	return l.rdb.Del(ctx, redisPrefix+key).Err()
 }
 
 func dur(f float64) time.Duration {

--- a/rate_test.go
+++ b/rate_test.go
@@ -37,6 +37,15 @@ func TestAllow(t *testing.T) {
 	assert.Equal(t, res.RetryAfter, time.Duration(-1))
 	assert.InDelta(t, res.ResetAfter, 100*time.Millisecond, float64(10*time.Millisecond))
 
+	err = l.Reset(ctx, "test_id")
+	assert.Nil(t, err)
+	res, err = l.Allow(ctx, "test_id", limit)
+	assert.Nil(t, err)
+	assert.Equal(t, res.Allowed, 1)
+	assert.Equal(t, res.Remaining, 9)
+	assert.Equal(t, res.RetryAfter, time.Duration(-1))
+	assert.InDelta(t, res.ResetAfter, 100*time.Millisecond, float64(10*time.Millisecond))
+
 	res, err = l.AllowN(ctx, "test_id", limit, 2)
 	assert.Nil(t, err)
 	assert.Equal(t, res.Allowed, 2)
@@ -57,6 +66,7 @@ func TestAllow(t *testing.T) {
 	assert.Equal(t, res.Remaining, 0)
 	assert.InDelta(t, res.RetryAfter, 99*time.Second, float64(time.Second))
 	assert.InDelta(t, res.ResetAfter, 999*time.Millisecond, float64(10*time.Millisecond))
+
 }
 
 func TestAllowAtMost(t *testing.T) {


### PR DESCRIPTION
Here I just added a new Lua script that removes the corresponding key from Redis to reset its functionality. 