### PR TITLE
enable allowN and allowAtMost to peek at contents

### DIFF
--- a/lua.go
+++ b/lua.go
@@ -57,7 +57,9 @@ if remaining < 0 then
 end
 
 local reset_after = new_tat - now
-redis.call("SET", rate_limit_key, new_tat, "EX", math.ceil(reset_after))
+if reset_after > 0 then
+  redis.call("SET", rate_limit_key, new_tat, "EX", math.ceil(reset_after))
+end
 local retry_after = -1
 return {cost, remaining, tostring(retry_after), tostring(reset_after)}
 `)

--- a/lua.go
+++ b/lua.go
@@ -123,7 +123,9 @@ local increment = emission_interval * cost
 local new_tat = tat + increment
 
 local reset_after = new_tat - now
-redis.call("SET", rate_limit_key, new_tat, "EX", math.ceil(reset_after))
+if reset_after > 0 then
+  redis.call("SET", rate_limit_key, new_tat, "EX", math.ceil(reset_after))
+end
 
 return {
   cost,

--- a/rate_test.go
+++ b/rate_test.go
@@ -68,6 +68,19 @@ func TestAllow(t *testing.T) {
 	require.InDelta(t, res.ResetAfter, 999*time.Millisecond, float64(10*time.Millisecond))
 }
 
+func TestAllowN_IncrementZero(t *testing.T) {
+	ctx := context.Background()
+	l := rateLimiter()
+	limit := redis_rate.PerSecond(10)
+
+	res, err := l.AllowN(ctx, "test_id", limit, 0)
+	require.Nil(t, err)
+	require.Equal(t, res.Allowed, 0)
+	require.Equal(t, res.Remaining, 10)
+	require.Equal(t, res.RetryAfter, time.Duration(-1))
+	require.Equal(t, res.ResetAfter, time.Duration(0))
+}
+
 func TestRetryAfter(t *testing.T) {
 	limit := redis_rate.Limit{
 		Rate:   1,

--- a/rate_test.go
+++ b/rate_test.go
@@ -159,6 +159,19 @@ func TestAllowAtMost(t *testing.T) {
 	require.InDelta(t, res.ResetAfter, 999*time.Millisecond, float64(10*time.Millisecond))
 }
 
+func TestAllowAtMost_IncrementZero(t *testing.T) {
+	ctx := context.Background()
+	l := rateLimiter()
+	limit := redis_rate.PerSecond(10)
+
+	res, err := l.AllowAtMost(ctx, "test_id", limit, 0)
+	require.Nil(t, err)
+	require.Equal(t, res.Allowed, 0)
+	require.Equal(t, res.Remaining, 10)
+	require.Equal(t, res.RetryAfter, time.Duration(-1))
+	require.Equal(t, res.ResetAfter, time.Duration(0))
+}
+
 func BenchmarkAllow(b *testing.B) {
 	ctx := context.Background()
 	l := rateLimiter()


### PR DESCRIPTION
If the caller wants to check what's there without mutating it, the lua script doesn't allow it when the row doesn't yet exist, because it tries to set a new row with an expiry of zero. This causes an error like:

```
ERR Error running script (call to f_b51fcf1fec2622e401ecd1495ba719a525362891): @user_script:54: ERR invalid expire time in set 
```

I think this approach is in line with what was suggested on #32 -- I changed both scripts to only try and set if the expiry ends up being greater than zero. This should preserve any existing functionality while also re-introducing the ability to peek at rows without altering them. This addresses the case where the row isn't there.