### PR TITLE
Allow customization of prefix used for redis keys

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-redis/redis/v8"
 )
 
-const redisPrefix = "rate:"
+const defaultRedisPrefix = "rate:"
 
 type rediser interface {
 	Eval(ctx context.Context, script string, keys []string, args ...interface{}) *redis.Cmd
@@ -73,13 +73,23 @@ func PerHour(rate int) Limit {
 
 // Limiter controls how frequently events are allowed to happen.
 type Limiter struct {
-	rdb rediser
+	rdb         rediser
+	redisPrefix string
 }
 
 // NewLimiter returns a new Limiter.
 func NewLimiter(rdb rediser) *Limiter {
 	return &Limiter{
-		rdb: rdb,
+		rdb:         rdb,
+		redisPrefix: defaultRedisPrefix,
+	}
+}
+
+// NewLimiter returns a new Limiter with a custom prefix.
+func NewLimiterWithPrefix(rdb rediser, redisPrefix string) *Limiter {
+	return &Limiter{
+		rdb:         rdb,
+		redisPrefix: redisPrefix,
 	}
 }
 
@@ -96,7 +106,7 @@ func (l Limiter) AllowN(
 	n int,
 ) (*Result, error) {
 	values := []interface{}{limit.Burst, limit.Rate, limit.Period.Seconds(), n}
-	v, err := allowN.Run(ctx, l.rdb, []string{redisPrefix + key}, values...).Result()
+	v, err := allowN.Run(ctx, l.rdb, []string{l.redisPrefix + key}, values...).Result()
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +142,7 @@ func (l Limiter) AllowAtMost(
 	n int,
 ) (*Result, error) {
 	values := []interface{}{limit.Burst, limit.Rate, limit.Period.Seconds(), n}
-	v, err := allowAtMost.Run(ctx, l.rdb, []string{redisPrefix + key}, values...).Result()
+	v, err := allowAtMost.Run(ctx, l.rdb, []string{l.redisPrefix + key}, values...).Result()
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +171,7 @@ func (l Limiter) AllowAtMost(
 
 // Reset gets a key and reset all limitations and previous usages
 func (l *Limiter) Reset(ctx context.Context, key string) error {
-	return l.rdb.Del(ctx, redisPrefix+key).Err()
+	return l.rdb.Del(ctx, l.redisPrefix+key).Err()
 }
 
 func dur(f float64) time.Duration {


### PR DESCRIPTION
Allows for the customisation of the rate key prefix with `NewLimiterWithPrefix`. This is a backwards-compatible change.