### PR TITLE
fix: panic for dragonfly 1.17 when interface convertation

### DIFF
--- a/rate.go
+++ b/rate.go
@@ -3,6 +3,7 @@ package redis_rate
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 	"time"
 
@@ -116,10 +117,20 @@ func (l Limiter) AllowN(
 		return nil, err
 	}
 
+	allowed, err := convertToInt(values[0])
+	if err != nil {
+		return nil, err
+	}
+
+	remaining, err := convertToInt(values[1])
+	if err != nil {
+		return nil, err
+	}
+
 	res := &Result{
 		Limit:      limit,
-		Allowed:    convertToInt(values[0]),
-		Remaining:  convertToInt(values[1]),
+		Allowed:    allowed,
+		Remaining:  remaining,
 		RetryAfter: dur(retryAfter),
 		ResetAfter: dur(resetAfter),
 	}
@@ -152,10 +163,20 @@ func (l Limiter) AllowAtMost(
 		return nil, err
 	}
 
+	allowed, err := convertToInt(values[0])
+	if err != nil {
+		return nil, err
+	}
+
+	remaining, err := convertToInt(values[1])
+	if err != nil {
+		return nil, err
+	}
+
 	res := &Result{
 		Limit:      limit,
-		Allowed:    convertToInt(values[0]),
-		Remaining:  convertToInt(values[1]),
+		Allowed:    allowed,
+		Remaining:  remaining,
 		RetryAfter: dur(retryAfter),
 		ResetAfter: dur(resetAfter),
 	}
@@ -174,16 +195,15 @@ func dur(f float64) time.Duration {
 	return time.Duration(f * float64(time.Second))
 }
 
-func convertToInt(value interface{}) int {
-	var remaining int = -1
-
+func convertToInt(value interface{}) (int, error) {
 	switch v := value.(type) {
 	case int64:
-		remaining = int(v)
+		return int(v), nil
 	case float64:
-		remaining = int(v)
+		return int(v), nil
+	default:
+		return 0, fmt.Errorf("value type is not match. Type: %s", reflect.TypeOf(value).Name())
 	}
-	return remaining
 }
 
 type Result struct {

--- a/rate.go
+++ b/rate.go
@@ -118,8 +118,8 @@ func (l Limiter) AllowN(
 
 	res := &Result{
 		Limit:      limit,
-		Allowed:    int(values[0].(int64)),
-		Remaining:  int(values[1].(int64)),
+		Allowed:    convertToInt(values[0]),
+		Remaining:  convertToInt(values[1]),
 		RetryAfter: dur(retryAfter),
 		ResetAfter: dur(resetAfter),
 	}
@@ -154,8 +154,8 @@ func (l Limiter) AllowAtMost(
 
 	res := &Result{
 		Limit:      limit,
-		Allowed:    int(values[0].(int64)),
-		Remaining:  int(values[1].(int64)),
+		Allowed:    convertToInt(values[0]),
+		Remaining:  convertToInt(values[1]),
 		RetryAfter: dur(retryAfter),
 		ResetAfter: dur(resetAfter),
 	}
@@ -172,6 +172,18 @@ func dur(f float64) time.Duration {
 		return -1
 	}
 	return time.Duration(f * float64(time.Second))
+}
+
+func convertToInt(value interface{}) int {
+	var remaining int = -1
+
+	switch v := value.(type) {
+	case int64:
+		remaining = int(v)
+	case float64:
+		remaining = int(v)
+	}
+	return remaining
 }
 
 type Result struct {


### PR DESCRIPTION
For dragonfly 1.17 got error: 
panic: interface conversion: interface {} is float64, not int64

This commit includes type checking